### PR TITLE
powerup destruction prevention

### DIFF
--- a/Assets/Scenes/1-1.unity
+++ b/Assets/Scenes/1-1.unity
@@ -1658,6 +1658,10 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 841438207429839045, guid: 2f45153d43a6e8449b8dca55e0850b64, type: 3}
     - target: {fileID: 2482177193003119388, guid: 962898cbc3d9ed649b7a54a9a408f125, type: 3}
+      propertyPath: brick
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2482177193003119388, guid: 962898cbc3d9ed649b7a54a9a408f125, type: 3}
       propertyPath: maxHits
       value: 5
       objectReference: {fileID: 0}
@@ -2368,6 +2372,10 @@ PrefabInstance:
       propertyPath: item
       value: 
       objectReference: {fileID: 1608222014282682259, guid: 30d9b35c65014314097a1b398e884949, type: 3}
+    - target: {fileID: 2482177193003119388, guid: 962898cbc3d9ed649b7a54a9a408f125, type: 3}
+      propertyPath: brick
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 2482177193003119388, guid: 962898cbc3d9ed649b7a54a9a408f125, type: 3}
       propertyPath: maxHits
       value: 1


### PR DESCRIPTION
made it so that bricks with powerups in them cant be destroyed by big mario.